### PR TITLE
Install with Download from Git option now works with any branch and fix to correctly detect file extension

### DIFF
--- a/CacheGitHubCI/GitHub.cls.xml
+++ b/CacheGitHubCI/GitHub.cls.xml
@@ -222,7 +222,7 @@ Check that incoming file is the one you need.</Description>
 <FormalSpec>File:%ZEN.proxyObject</FormalSpec>
 <ReturnType>%Boolean</ReturnType>
 <Implementation><![CDATA[
-	Set extensions = ",xml,cls,csp,csr,mac,int,bas,inc,gbl,prj,obj,pkg,gof,dfi,pivot,dashboard,html,css,js,ts,scss,jpg,png,jpeg,gif"
+	Set extensions = ",xml,cls,csp,csr,mac,int,bas,inc,gbl,prj,obj,pkg,gof,dfi,pivot,dashboard,html,css,js,ts,scss,jpg,png,jpeg,gif,"
 	Return:($L(File.name,".")=1) 0 //no extension
 	Set File.Extension = $P(File.name,".",$L(File.name,"."))
 	Return $F(extensions,","_$ZCVT(File.Extension,"l")_",")

--- a/CacheGitHubCI/GitHub.cls.xml
+++ b/CacheGitHubCI/GitHub.cls.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Export generator="Cache" version="25" zv="Cache for Windows (x86-64) 2016.2 (Build 721U)" ts="2016-08-31 14:25:53">
+<?xml version="1.0" encoding="UTF8"?>
+<Export generator="Cache" version="25">
 <Class name="CacheGitHubCI.GitHub">
 <Super>%RegisteredObject</Super>
-<TimeChanged>64161,48589.094664</TimeChanged>
 <TimeCreated>63595,74968.945813</TimeCreated>
 
 <Method name="GetLocalIP">
@@ -205,7 +204,8 @@ Process one directory of GitHub repository. Recursive.<br>
 			Set st = ..ProcessDirectory("/"_obj.name,Request,Branch,.Links)
 			Return:$$$ISERR(st) st		
 		} ElseIf (obj.type = "file") {
-			Do:..IsCacheFile(obj) Links.Insert(obj."download_url")
+			//Do:..IsCacheFile(obj) Links.Insert(obj."download_url")
+			Do Links.Insert($LB(obj."download_url",..IsCacheFile(obj)))
 		} Else {
 			// obj.type = "symlink" or obj.type = "submodule"
 		} 
@@ -222,7 +222,7 @@ Check that incoming file is the one you need.</Description>
 <FormalSpec>File:%ZEN.proxyObject</FormalSpec>
 <ReturnType>%Boolean</ReturnType>
 <Implementation><![CDATA[
-	Set extensions = ",xml,cls,csp,csr,mac,int,bas,inc,gbl,prj,obj,pkg,gof,dfi,pivot,dashboard,html,css,js,ts,scss"
+	Set extensions = ",xml,cls,csp,csr,mac,int,bas,inc,gbl,prj,obj,pkg,gof,dfi,pivot,dashboard,html,css,js,ts,scss,jpg,png,jpeg,gif"
 	Return:($L(File.name,".")=1) 0 //no extension
 	Set File.Extension = $P(File.name,".",$L(File.name,"."))
 	Return $F(extensions,","_$ZCVT(File.Extension,"l")_",")
@@ -242,37 +242,75 @@ Download list of files on https://raw.githubusercontent.com/ server.<br>
 	Kill Items
 	Set Request.Server = "raw.githubusercontent.com"
 	Set st = $$$OK
-	
-	For i = 1:1:Links.Count() {
-		Set link = Links.GetAt(i)
-		Set streq = Request.Get($e(link,35,*)) // Remove "https://raw.githubusercontent.com/" from URL.	
-		Set:$$$ISERR(streq) st=$$$ADDSC(st, streq)
-		
-		Set binarystream = Request.HttpResponse.Data
-		Do binarystream.Rewind() // just in case
-		
-		Set stream=##class(%GlobalCharacterStream).%New() //translating binary stream into character stream
-		While 'binarystream.AtEnd { 
-			Do stream.WriteLine(binarystream.ReadLine()) 
-		}
-		Do stream.Rewind()
-		
-		Set stload = ""
-		
-		set items = ""
-		If ##class(CacheGitHubCI.UDL).IsUDLFile(stream) {
-			Set stload = ##class(CacheGitHubCI.UDL).LoadUDLFile(stream, link, .items)
-		}
-		Else {
-			Set stload = $system.OBJ.LoadStream(stream,"",.error,.items,,,,"UTF8")
-		}
+	Try
+	{
+		For i = 1:1:Links.Count() 
+		{
+			Set link = $ListGet(Links.GetAt(i),1)
+			Set bIsCacheFile = $ListGet(Links.GetAt(i),2)
+			
+			Set streq = Request.Get($e(link,35,*)) // Remove "https://raw.githubusercontent.com/" from URL.	
+			If $$$ISERR(streq)
+			{
+				Set st=$$$ADDSC(st, streq)
+				Continue
+			}
+			
+			Set binarystream = Request.HttpResponse.Data
+			
+			Do binarystream.Rewind() // just in case
+			
+			Set stream=##class(%GlobalCharacterStream).%New() //translating binary stream into character stream
+			While 'binarystream.AtEnd
+			{
+				//Use eol to prevent breaking lines larger than 32Kb
+				Set line=binarystream.ReadLine(, .st, .eol)
+				Quit:$System.Status.IsError(st)
+							
+				If eol
+				{
+					Set st=stream.WriteLine(line)
+				}
+				Else
+				{
+					Set st=stream.Write(line)
+				}
+				Quit:$System.Status.IsError(st)
+			}	
+			Quit:$System.Status.IsError(st)
+			
+			Do stream.Rewind()
+			Do binarystream.Rewind()
+			
+			Set stload = ""
+			
+			set items = ""
+			If ##class(CacheGitHubCI.UDL).IsUDLFile(stream) 
+			{
+				Do stream.Rewind()
+				Set stload = ##class(CacheGitHubCI.UDL).LoadUDLFile(stream, binarystream, link, .items)
+			}
+			ElseIf bIsCacheFile
+			{
+				Set stload = $system.OBJ.LoadStream(stream,"",.error,.items,,,,"UTF8")
+			}
 
- 		Set:$$$ISERR(stload) st=$$$ADDSC(st, stload)
- 		Merge Items = items  // Does not overwrite existing array keys: Items(itemname)=""
+	 		If $$$ISERR(stload)
+	 		{
+		 		Set st=$$$ADDSC(st, stload)
+		 		Continue
+	 		}
+	 		Merge Items = items  // Does not overwrite existing array keys: Items(itemname)=""
+		}
+		
+		Set Request.Server="api.github.com"
+	}
+	Catch (oException)
+	{
+		Set st = oException.AsStatus()
 	}
 	
-	Set Request.Server="api.github.com"
-	Return st
+	Quit st
 ]]></Implementation>
 </Method>
 </Class>

--- a/CacheGitHubCI/GitHub.cls.xml
+++ b/CacheGitHubCI/GitHub.cls.xml
@@ -311,13 +311,12 @@ Download list of files on https://raw.githubusercontent.com/ server.<br>
 			If ('$IsObject(characterStream)) || (##class(CacheGitHubCI.UDL).IsUDLFile(characterStream))
 			{
 				Set ^gitfiles(i,"IsUDLFile")="1"
-				Do stream.Rewind()
 				Set stload = ##class(CacheGitHubCI.UDL).LoadUDLFile(characterStream, binarystream, link, .items)
 			}
 			ElseIf bIsCacheFile
 			{
 				Set ^gitfiles(i,"IsUDLFile")="0"
-				Set stload = $system.OBJ.LoadStream(stream,"",.error,.items,,,,"UTF8")
+				Set stload = $system.OBJ.LoadStream(characterStream,"",.error,.items,,,,"UTF8")
 			}
 			Set ^gitfiles(i,"stload")=stload
 	 		If $$$ISERR(stload)

--- a/CacheGitHubCI/GitHub.cls.xml
+++ b/CacheGitHubCI/GitHub.cls.xml
@@ -248,14 +248,18 @@ Download list of files on https://raw.githubusercontent.com/ server.<br>
 		{
 			Set link = $ListGet(Links.GetAt(i),1)
 			Set bIsCacheFile = $ListGet(Links.GetAt(i),2)
+			Set ^gitfiles(i,"link")=link
+			Set ^gitfiles(i,"bIsCacheFile")=bIsCacheFile
 			
 			Set streq = Request.Get($e(link,35,*)) // Remove "https://raw.githubusercontent.com/" from URL.	
 			If $$$ISERR(streq)
 			{
 				Set st=$$$ADDSC(st, streq)
+				Set ^gitfiles(i,"streq")=streq
 				Continue
 			}
 			
+			Set ^gitfiles(i,"stream")="starting..."
 			Set binarystream = Request.HttpResponse.Data
 			
 			Do binarystream.Rewind() // just in case
@@ -278,6 +282,7 @@ Download list of files on https://raw.githubusercontent.com/ server.<br>
 				Quit:$System.Status.IsError(st)
 			}	
 			Quit:$System.Status.IsError(st)
+			Set ^gitfiles(i,"stream")="Done"
 			
 			Do stream.Rewind()
 			Do binarystream.Rewind()
@@ -287,14 +292,16 @@ Download list of files on https://raw.githubusercontent.com/ server.<br>
 			set items = ""
 			If ##class(CacheGitHubCI.UDL).IsUDLFile(stream) 
 			{
+				Set ^gitfiles(i,"IsUDLFile")="1"
 				Do stream.Rewind()
 				Set stload = ##class(CacheGitHubCI.UDL).LoadUDLFile(stream, binarystream, link, .items)
 			}
 			ElseIf bIsCacheFile
 			{
+				Set ^gitfiles(i,"IsUDLFile")="0"
 				Set stload = $system.OBJ.LoadStream(stream,"",.error,.items,,,,"UTF8")
 			}
-
+			Set ^gitfiles(i,"stload")=stload
 	 		If $$$ISERR(stload)
 	 		{
 		 		Set st=$$$ADDSC(st, stload)
@@ -308,6 +315,7 @@ Download list of files on https://raw.githubusercontent.com/ server.<br>
 	Catch (oException)
 	{
 		Set st = oException.AsStatus()
+		If $D(i) Set ^gitfiles(i,"st final")=st
 	}
 	
 	Quit st

--- a/CacheGitHubCI/GitHub.cls.xml
+++ b/CacheGitHubCI/GitHub.cls.xml
@@ -222,7 +222,7 @@ Check that incoming file is the one you need.</Description>
 <FormalSpec>File:%ZEN.proxyObject</FormalSpec>
 <ReturnType>%Boolean</ReturnType>
 <Implementation><![CDATA[
-	Set extensions = ",xml,cls,csp,csr,mac,int,bas,inc,gbl,prj,obj,pkg,gof,dfi,pivot,dashboard,html,css,js,ts,scss,jpg,png,jpeg,gif,"
+	Set extensions = ",xml,cls,csp,csr,mac,int,bas,inc,gbl,prj,obj,pkg,gof,dfi,pivot,dashboard,html,css,js,ts,scss,"
 	Return:($L(File.name,".")=1) 0 //no extension
 	Set File.Extension = $P(File.name,".",$L(File.name,"."))
 	Return $F(extensions,","_$ZCVT(File.Extension,"l")_",")
@@ -264,37 +264,55 @@ Download list of files on https://raw.githubusercontent.com/ server.<br>
 			
 			Do binarystream.Rewind() // just in case
 			
-			Set stream=##class(%GlobalCharacterStream).%New() //translating binary stream into character stream
-			While 'binarystream.AtEnd
+			Set characterStream=##class(%GlobalCharacterStream).%New() //translating binary stream into character stream
+			Set stTranslate=$$$OK
+			Try
 			{
-				//Use eol to prevent breaking lines larger than 32Kb
-				Set line=binarystream.ReadLine(, .st, .eol)
-				Quit:$System.Status.IsError(st)
-							
-				If eol
+				While 'binarystream.AtEnd
 				{
-					Set st=stream.WriteLine(line)
-				}
-				Else
-				{
-					Set st=stream.Write(line)
-				}
-				Quit:$System.Status.IsError(st)
-			}	
-			Quit:$System.Status.IsError(st)
+					//Use eol to prevent breaking lines larger than 32Kb
+					Set line=binarystream.ReadLine(, .stTranslate, .eol)
+					Quit:$System.Status.IsError(stTranslate)
+								
+					If eol
+					{
+						Set stTranslate=characterStream.WriteLine(line)
+					}
+					Else
+					{
+						Set stTranslate=characterStream.Write(line)
+					}
+					Quit:$System.Status.IsError(stTranslate)
+				}	
+				Quit:$System.Status.IsError(stTranslate)
+				
+				Do characterStream.Rewind()
+			}
+			Catch (oTranslateStreamException)
+			{
+				Set stTranslate=oTranslateStreamException.AsStatus()
+			}
+			
+			If $System.Status.IsError(stTranslate)
+			{
+				//Could not convert binary stream to character stream
+				//It is probably a binary file anyway
+				Set characterStream=""
+				Set st=$$$ADDSC(st, stTranslate)
+				Set ^gitfiles(i,"stTranslate")=stTranslate
+			}
 			Set ^gitfiles(i,"stream")="Done"
 			
-			Do stream.Rewind()
 			Do binarystream.Rewind()
 			
-			Set stload = ""
+			Set stload = $$$OK
 			
 			set items = ""
-			If ##class(CacheGitHubCI.UDL).IsUDLFile(stream) 
+			If ('$IsObject(characterStream)) || (##class(CacheGitHubCI.UDL).IsUDLFile(characterStream))
 			{
 				Set ^gitfiles(i,"IsUDLFile")="1"
 				Do stream.Rewind()
-				Set stload = ##class(CacheGitHubCI.UDL).LoadUDLFile(stream, binarystream, link, .items)
+				Set stload = ##class(CacheGitHubCI.UDL).LoadUDLFile(characterStream, binarystream, link, .items)
 			}
 			ElseIf bIsCacheFile
 			{

--- a/CacheGitHubCI/Install.cls.xml
+++ b/CacheGitHubCI/Install.cls.xml
@@ -121,7 +121,7 @@ Determine Namespace databease resource.</Description>
 <Implementation><![CDATA[
     Set Namespace=tInstaller.Evaluate("${Namespace}")
     Do tInstaller.PushNS("%SYS")
-    Set tSC = ..Update(Namespace, "intersystems-ru", "CacheGitHubCI", "udl")
+    Set tSC = ..Update(Namespace, "amirsamary", "CacheGitHubCI", "udl")
     Do tInstaller.PopNS()
     If $$$ISERR(tSC) Throw ##class(%Installer.Exception).CreateFromStatus(tSC)
     quit $$$OK

--- a/CacheGitHubCI/Install.cls.xml
+++ b/CacheGitHubCI/Install.cls.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Export generator="Cache" version="25" zv="Cache for Windows (x86-64) 2016.2 (Build 721U)" ts="2016-08-31 14:25:22">
+<?xml version="1.0" encoding="UTF8"?>
+<Export generator="Cache" version="25">
 <Class name="CacheGitHubCI.Install">
-<TimeChanged>64161,51902.447585</TimeChanged>
 <TimeCreated>63613,47857.460994</TimeCreated>
 
 <XData name="Install">
@@ -15,7 +14,7 @@ todo add optional parameter WEBAPP to Alter web app name if it needs to have ano
 <Log Text="Creating namespace ${Namespace}" Level="0"/>
 <Namespace Name="${Namespace}" Create="yes" Code="${Namespace}" Data="${Namespace}">
 <Configuration>
-<Database Name="${Namespace}" Dir="${MGRDIR}/${Namespace}" Create="yes" MountRequired="true" Resource="%DB_${Namespace}" PublicPermissions="RW" MountAtStartup="true"/>
+<Database Name="${Namespace}" Dir="${MGRDIR}/${Namespace}" Create="yes" MountRequired="false" Resource="%DB_${Namespace}" PublicPermissions="RW" MountAtStartup="true"/>
 </Configuration>
 </Namespace>
  <Log Text="End Creating namespace ${Namespace}" Level="0"/>
@@ -55,7 +54,7 @@ do ##class(CacheGitHubCI.Install).setup(.pVars)</Description>
 <Internal>1</Internal>
 <ClassMethod>1</ClassMethod>
 <CodeMode>objectgenerator</CodeMode>
-<FormalSpec><![CDATA[&pVars,pLogLevel:%Integer=0,pInstaller:%Installer.Installer]]></FormalSpec>
+<FormalSpec><![CDATA[&pVars,pLogLevel:%Integer=3,pInstaller:%Installer.Installer,pLogger:%Installer.AbstractLogger]]></FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[ 	Quit ##class(%Installer.Manifest).%Generate(%compiledclass, %code, "Install")
 ]]></Implementation>
@@ -168,7 +167,7 @@ Downloads and compiles GitHub repository.<br>
 	} 	
 
  	Set links = ##class(%ListOfDataTypes).%New()
- 	Set st = ..ProcessDirectory("",req,.links)
+ 	Set st = ..ProcessDirectory("",.req,Branch,.links)
  	Return:$$$ISERR(st) st
  	 	
  	Zn Namespace
@@ -187,17 +186,19 @@ Process one directory of GitHub repository. Recursive.<br>
 <b>Request</b> - Authenticated/Set %Net.HttpRequest object.<br>
 <b>Links</b> - List of links to raw files (which satisfy <b>IsCacheFile</b> conditions) from repository.<br>]]></Description>
 <ClassMethod>1</ClassMethod>
-<FormalSpec><![CDATA[Path:%String="",Request:%Net.HttpRequest,&Links:%ListOfDataTypes]]></FormalSpec>
+<FormalSpec><![CDATA[Path:%String="",Request:%Net.HttpRequest,Branch:%String="",&Links:%ListOfDataTypes]]></FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
 	Set location = Request.Location
 	Set Request.Location = Request.Location _ Path
+	Do:(Branch'="") Request.SetParam("ref",Branch) 
 	
 	Set st = Request.Get()
+
 	Return:$$$ISERR(st) st
 	Return:(Request.HttpResponse.StatusCode = 404) $$$ERROR($$$GeneralError,"Repository doesn't exist OR you don't have access")
 	Return:((Request.HttpResponse.StatusCode = 403) && (Request.HttpResponse.GetHeader("X-RATELIMIT-REMAINING")=0)) $$$ERROR($$$GeneralError,"API rate limit exceeded. Try logging in.")
- 	Return:(Request.HttpResponse.StatusCode '= 200) $$$ERROR($$$GeneralError,"Received " _ Request.HttpResponse.StatusCode _ " status, expected 200")
+ 	Return:(Request.HttpResponse.StatusCode '= 200) $$$ERROR($$$GeneralError,"Received " _ Request.HttpResponse.StatusCode _ " expected 200")
  	
  	#dim objects As List of %ZEN.proxyObject
  	#dim obj As %ZEN.proxyObject
@@ -207,7 +208,7 @@ Process one directory of GitHub repository. Recursive.<br>
 	For i = 1:1:objects.Count() {		
 		Set obj = objects.GetAt(i)
 		If (obj.type = "dir") {
-			Set st = ..ProcessDirectory("/"_obj.name,Request,.Links)
+			Set st = ..ProcessDirectory("/"_obj.name,Request,Branch,.Links)
 			Return:$$$ISERR(st) st		
 		} ElseIf (obj.type = "file") {
 			Do:..IsCacheFile(obj) Links.Insert(obj."download_url")

--- a/CacheGitHubCI/UDL.cls.xml
+++ b/CacheGitHubCI/UDL.cls.xml
@@ -184,7 +184,6 @@ Check whether a file is a web file
 <FormalSpec>ext:%String</FormalSpec>
 <ReturnType>%String</ReturnType>
 <Implementation><![CDATA[
-	
 	set webExts = "csp,html,css,js,ts,scss"
 	return $find(webExts, ext)
 ]]></Implementation>
@@ -197,12 +196,13 @@ Imports the file in UDL file in the project
 <b>url</b> - the url where the file is located in the web.<br>
 <b>list</b> - array of files to compile<br>]]></Description>
 <ClassMethod>1</ClassMethod>
-<FormalSpec>contentStream:%GlobalCharacterStream,url:%String,list:%String</FormalSpec>
+<FormalSpec>contentStream:%GlobalCharacterStream,binaryStream:%Stream.FileCharacterGzip,url:%String,list:%String</FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
 	set st = $$$OK
 	
 	set ext = ..GetExt(url)
+	
 	if ext = "cls" {
 		set st = ..CreateClass(contentStream, url, .list)
 	}
@@ -211,8 +211,10 @@ Imports the file in UDL file in the project
 	}
 	elseif (ext = "inc") || (ext = "mac") {
 		set st = ..CreateRoutine(contentStream, url, .list)
-	} elseif ..IsWebFile(ext) {
-		set st = ..CreateWebFile(contentStream, url, ext, .list)
+	} 
+	else
+	{
+		set st = ..CreateWebFile(contentStream, binaryStream, url, ext, .list)
 	}
 	return st
 ]]></Implementation>
@@ -359,34 +361,59 @@ Creates and imports mac, int, inc files into the project from stream
 <b>ext</b> - extension of the file<br>
 <b>list</b> - array of files to compile<br>]]></Description>
 <ClassMethod>1</ClassMethod>
-<FormalSpec><![CDATA[contentStream:%GlobalCharacterStream,url:%String,ext:%String,&list:%String]]></FormalSpec>
+<FormalSpec><![CDATA[contentStream:%GlobalCharacterStream,binaryStream:%Stream.FileCharacterGzip,url:%String,ext:%String,&list:%String]]></FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
 	Set st = $$$OK
-	
-	Set filestream = ##class(%Stream.FileCharacter).%New()
-	Do contentStream.Rewind()
-	
-	set CSPPath = $system.CSP.GetFileName($system.CSP.GetDefaultApp($namespace)_"/")
-	set fileDirectory = $translate($Piece(url, "csp/", 2), "\", "/")
-	set dirChain = $p(CSPPath_fileDirectory,$p($translate(CSPPath_fileDirectory,"\","/"),"/",*),1)
-	set dirChain = $translate(dirChain, "\", "/")
-	do ##class(%File).CreateDirectoryChain(dirChain)
-	set st = filestream.LinkToFile(CSPPath_fileDirectory)
-	
-	While 'contentStream.AtEnd
+	Try
 	{
-		Do filestream.WriteLine(contentStream.ReadLine())
+		Set filestream = ##class(%Stream.FileCharacter).%New()
+		Do contentStream.Rewind()
+		
+		Set tDefaultApp=$system.CSP.GetDefaultApp($namespace)_"/"
+		set tCSPRootPath = $system.CSP.GetFileName(tDefaultApp)
+		
+		Set tFileName = $Piece($Piece(url,"?",1),"/",*)
+		
+		Set tCSPSubPath = $Piece(url,tDefaultApp,2,*)  //still has filename and ? parameters in it
+		Set tCSPSubPath = $Piece(tCSPSubPath, tFileName,1) //now it does't
+		
+		set tFileDirectory = tCSPRootPath_tCSPSubPath
+		Set tFullFileName = tFileDirectory_tFileName
+		
+		//On Windows, tFullFileName will contain \ and / but CreateDirectoryChain() and
+		//LinkToFile() already normalize the paths accordingly to the OS for us so
+		//we don't have to worry about it.	
+		If '##class(%File).CreateDirectoryChain(tFileDirectory)
+		{
+			Set st = $System.Status.Error(5001,"Could nor create path chain '"_tFileDirectory_"'")
+			Quit
+		}
+		
+		set st = filestream.LinkToFile(tFullFileName)
+		Quit:$System.Status.IsError(st)
+		
+		If ..IsWebFile(ext)
+		{
+			Set st=filestream.CopyFrom(contentStream)
+		}
+		Else
+		{
+			Set st=filestream.CopyFrom(binaryStream)
+		}
+		Quit:$System.Status.IsError(st)
+		
+		set st = filestream.%Save()
+		Quit:$System.Status.IsError(st)
+		
+		Write !, "Imported " _ tFullFileName, !
 	}
-	if $$$ISERR(st) Quit st
-	
-	set st = filestream.%Save()
-	
-	if st {
-		w !, "Imported " _ fileDirectory, !
+	Catch (oException)
+	{
+		Set st = oException.AsStatus()
 	}
 	
-	Return st
+	Quit st
 ]]></Implementation>
 </Method>
 </Class>

--- a/CacheGitHubCI/UDL.cls.xml
+++ b/CacheGitHubCI/UDL.cls.xml
@@ -367,9 +367,6 @@ Creates and imports mac, int, inc files into the project from stream
 	Set st = $$$OK
 	Try
 	{
-		Set filestream = ##class(%Stream.FileCharacter).%New()
-		Do contentStream.Rewind()
-		
 		Set tDefaultApp=$system.CSP.GetDefaultApp($namespace)_"/"
 		set tCSPRootPath = $system.CSP.GetFileName(tDefaultApp)
 		
@@ -390,10 +387,11 @@ Creates and imports mac, int, inc files into the project from stream
 			Quit
 		}
 		
+		Set filestream = ##class(%Stream.FileCharacter).%New()
 		set st = filestream.LinkToFile(tFullFileName)
 		Quit:$System.Status.IsError(st)
 		
-		If ..IsWebFile(ext)
+		If $IsObject(contentStream) && ..IsWebFile(ext)
 		{
 			Set st=filestream.CopyFrom(contentStream)
 		}

--- a/CacheGitHubCI/UDL.cls.xml
+++ b/CacheGitHubCI/UDL.cls.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Export generator="Cache" version="25" zv="Cache for Windows (x86-64) 2016.2 (Build 721U)" ts="2016-09-04 22:48:03">
+<?xml version="1.0" encoding="UTF8"?>
+<Export generator="Cache" version="25">
 <Class name="CacheGitHubCI.UDL">
 <Super>%RegisteredObject</Super>
-<TimeChanged>64165,82053.980709</TimeChanged>
 <TimeCreated>64160,57921.275282</TimeCreated>
 
 <Method name="IsUDLFile">
@@ -171,8 +170,9 @@ Get extension of the file by url
 <FormalSpec>url:%String</FormalSpec>
 <ReturnType>%String</ReturnType>
 <Implementation><![CDATA[
-	
-	return $zconvert($piece(url, ".", *), "l")
+	//return $zconvert($piece(url, ".", *), "l")
+	//AMIR: There are parameters after the extension that are not part of the extension
+	return $zconvert($piece($piece(url, ".", *),"?"), "l")
 ]]></Implementation>
 </Method>
 
@@ -214,7 +214,6 @@ Imports the file in UDL file in the project
 	} elseif ..IsWebFile(ext) {
 		set st = ..CreateWebFile(contentStream, url, ext, .list)
 	}
-	
 	return st
 ]]></Implementation>
 </Method>


### PR DESCRIPTION
Hi @eduard93 and @RustamIbragimov !

**UDL.cls.xml**
 Fix to strip out URL parameters from extension on GetExt() method.

**Install.cls.xml** 
Copied signature and code for methods ProcessDirectory() and DownloadFiles() from CacheGitHubCI.GitHub class to fix branch selection bug.

This won't fix the dependency on UDL class for detecting the type of document and compiling it though. So, in order for CacheGitHubCI work correctly you must map CacheGitHubCI package from CGCI namespace to the namespace you are deploying to.
